### PR TITLE
Fixed typographical error, changed abritrary to arbitrary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Handles commodities/funds properly.
 #### `mint2ledger`
 Import Mint transactions.
 
-Combines transfers between accounts, and allows for abritrary renaming of
+Combines transfers between accounts, and allows for arbitrary renaming of
 transactions.
 
 #### `dwolla2ledger`


### PR DESCRIPTION
clehner, I've corrected a typographical error in the documentation of the [ledger-scripts](https://github.com/clehner/ledger-scripts) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
